### PR TITLE
fix: Use correct data path for error type

### DIFF
--- a/lib/ApiHelper.js
+++ b/lib/ApiHelper.js
@@ -181,7 +181,7 @@ class ApiHelper {
                 let data = response.data;
                 // Checking for a failed authentication
                 if(data.error){
-                    if(data.error.name === 'InvalidUserException'){
+                    if(data.error.data.type === 'InvalidUserException'){
                         // Doesn't hurt to clear even if we're not remembering/storing them
                         this.clearLocalCredentials();
                         // Assuming there was a timeout, re-running authentication


### PR DESCRIPTION
Request (used a random/nonexistent sessionId):
```
{
"method" : "Get",
    "params" : {
        "typeName" : "Device",
        "credentials" : {
            "database" : "<redacted>",
            "userName" : "<redacted>",
            "sessionId" : "etattgeageag"
        },
        "search" : {
            "name" : <redacted>
        }
    }
}
```

Response
```
{
    "error": {
        "message": "Incorrect login credentials",
        "code": -32000,
        "data": {
            "id": "0dfed192-151c-4d8f-8769-3e0690e3a2cf",
            "type": "InvalidUserException",
            "requestIndex": 0
        },
        "name": "JSONRPCError",
        "errors": [
            {
                "message": "Incorrect login credentials",
                "name": "InvalidUserException"
            }
        ]
    },
    "jsonrpc": "2.0",
    "requestIndex": 0
}
```

The current path to check if the error is an `InvalidUserException` is `data.error.name`. That path does not exist in the response object. Made a small change to check the correct path for the error type.