### PR TITLE
[MYG-57355] Return error JSON for callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,14 +125,27 @@ api.call('Get', { typeName: 'Device', resultsLimit: 100 })
     });
 ```
 
-Using callbacks will allow you to pass in your own logic to be executed when the call is complete. The standard pattern for callback responses is as follows:
+Using callbacks will allow you to pass in your own logic to be executed when the call is complete. The standard pattern for success callback is as follows:
 
 ```javascript
-function callback(result){
+function callbackSuccess(result){
     //Your response logic
     console.log(result);
 }
 ```
+
+Error callbacks have two parameters: `message` and `error`. `message` is a condensed `string` form of `error` for convience. In the case of a non-200 status code failure, `error` is an instance of `Error`. In all other cases, it is the full error JSON returned from the API call. 
+
+```javascript
+function callbackError(message, error){
+    //Your response logic
+    console.log(message);
+    console.log(error.data);
+}
+```
+For more information on the error JSON structure returned from MyGeotab API, see [here](https://geotab.github.io/sdk/software/guides/concepts/#results-and-errors).
+
+Note: `error` parameter in a `.catch` statement always returns an instance of `Error`. 
 
 ### Authentication
 
@@ -144,7 +157,7 @@ await api.authenticate().then( response => console.log('I have authenticated'));
 // OR
 api.authenticate( success => {
     console.log('Successful authentication');
-}, (error) => {
+}, (message, error) => {
     console.log('Something went wrong');
 });
 ```
@@ -176,7 +189,7 @@ api.call('Get', {
     if (result) {
         console.log(result);
     }
-}, function (err) {
+}, function (message, err) {
     console.error(err);
 });
 ```
@@ -213,9 +226,9 @@ api.multiCall([
     if (result) {
         console.log(result);
     }
-}, function (err) {
+}, function (message, err) {
     console.error(err);
-}));
+});
 ```
 
 ### Forget

--- a/lib/ApiHelper.js
+++ b/lib/ApiHelper.js
@@ -137,19 +137,32 @@ class ApiHelper {
     /**
      * Error handling - only called if fullresponse isn't enabled, and if the user hasn't provided a callback
      * @param {Promise} call Axios call
+     * @param {function} callbackError Optional callback for unsuccessful calls
      */
-    errorHandle(call) {
+    errorHandle(call, callbackError) {
         // User hasn't asked for the full axios object, so we should error check
         return call
             .then(response => {
                 if (response.status !== 200) {
-                    throw new Error(`Response ${response.status} - ${response.statusText}`);
+                    let error = new Error(`Response ${response.status} - ${response.statusText}`);
+
+                    if (callbackError) {
+                        callbackError(error.toString(), error);
+                    } else {
+                        throw error;
+                    }
                 }
                 return response;
             })
             .then(response => {
                 if (response.data.error) {
-                    throw new Error(`${response.data.error.data.type}: ${response.data.error.message}`);
+                    let error = new Error(`${response.data.error.data.type}: ${response.data.error.message}`);
+
+                    if (callbackError) {
+                        callbackError(error.toString(), response.data.error);
+                    } else {
+                        throw error;
+                    }
                 }
                 return response;
             });

--- a/lib/GeotabApi.js
+++ b/lib/GeotabApi.js
@@ -43,14 +43,8 @@ class GeotabApi {
             userName: this._helper.userName,
             password: this._helper.password
         }
-        let result = this.callimpl('Authenticate', options, callbackSuccess);
+        let result = this.callimpl('Authenticate', options, callbackSuccess, callbackError);
 
-        if (callbackError) {
-            await result.catch(error => {
-                // If we got a callbackError, we can catch the error and use it
-                callbackError(error.toString(), error);
-            });
-        }
         if (!callbackSuccess && !callbackError) {
             return result;
         }
@@ -71,14 +65,8 @@ class GeotabApi {
             throw new Error(`If callbackSuccess is supplied so must callbackError`);
         }
 
-        let result = this.callimpl(method, params, callbackSuccess);
+        let result = this.callimpl(method, params, callbackSuccess, callbackError);
 
-        if (callbackError) {
-            await result.catch(error => {
-                // If we got a callbackError, we can catch the error and use it
-                callbackError(error.toString(), error);
-            });
-        }
         if (!callbackSuccess && !callbackError) {
             return result;
         }
@@ -125,10 +113,7 @@ class GeotabApi {
         let call = this._helper.sendAxiosCall(method, params, callbackSuccess, callbackError, this.authenticate, this._helper.rememberMe);
         // Seeing if the user wants the axios response object, or default error handling
         if (!this._helper.fullResponse) {
-            if (typeof callbackError !== 'function') {
-                // Error handling comes first to filter out non-200 errors
-                call = this._helper.errorHandle(call);
-            }
+            call = this._helper.errorHandle(call, callbackError);
             call = this._helper.parseAxiosResponse(call);
         }
         // Returning call to user
@@ -160,12 +145,6 @@ class GeotabApi {
             calls: formattedCalls
         }, callbackSuccess, callbackError);
 
-        if (callbackError) {
-            await result.catch(error => {
-                // If we got a callbackError, we can catch the error and use it
-                callbackError(error.toString(), error);
-            });
-        }
         if (!callbackSuccess && !callbackError) {
             return result;
         }

--- a/test/node/nocks/nock.js
+++ b/test/node/nocks/nock.js
@@ -108,7 +108,34 @@ getCount
 
 const multiCall = nock(`https://${mocks.server}/apiv1/`)
                 .persist()
-                .post('/', (body) => {
-                    return body.method === 'ExecuteMultiCall'
-                })
-                .reply(200, {result: [2000, 2001]})
+
+multiCall
+    .post('/', (body) => {
+        let methodNamesCorrect = body.params.calls.every((call) => call.method === 'GetCountOf');
+        return body.method === 'ExecuteMultiCall' && methodNamesCorrect
+    })
+    .reply(200, {result: [2000, 2001]})
+
+multiCall
+    .post('/', (body) => {
+        let methodNamesIncorrect = body.params.calls.some((call) => call.method === 'GetCountOff');
+        return body.method === 'ExecuteMultiCall' && methodNamesIncorrect;
+    })
+    .reply(200, {
+        error: {
+            message: "The method 'GetCountOff' could not be found. Verify the method name and ensure all method parameters are included.",
+            code: -32601,
+            data: {
+                id: "ee15868e-6d47-41de-bafc-b20c1ca95152",
+                type: "MissingMethodException",
+                requestIndex: 1
+            },
+            name: "JSONRPCError",
+            errors: [
+                {
+                    message: "The method 'Ge' could not be found. Verify the method name and ensure all method parameters are included.",
+                    name: "MissingMethodException"
+                }
+            ]
+        },
+    })

--- a/test/node/node-Credentials-Invalid.spec.js
+++ b/test/node/node-Credentials-Invalid.spec.js
@@ -73,4 +73,54 @@ describe('User loads GeotabApi node module and triggers an error (Credentials)',
                             .catch( err => err );
         assert.isTrue(response.message.includes('MissingMethodException'), 'Promise response undefined');
     });
+
+    it('Api should gracefully handle a multicall failure (Callback)', async () => {
+        let login = mocks.login;
+        let api = new GeotabApi({
+                credentials: {
+                    database: login.credentials.database,
+                    userName: login.credentials.username,
+                    password: login.credentials.password
+                },
+                path: login.path,
+        }, {rememberMe: false});
+
+        let response = await new Promise((resolve, reject) => {
+            let calls = [
+                ["GetCountOff", { typeName: "Device" }],
+                ["GetCountOf", { typeName: "User" }]
+            ];
+            api.multiCall(calls, function(success){
+                resolve(success);
+            }, function(message, error){
+                reject(error);
+            });
+        })
+        .then( resolved => resolved )
+        .catch( error => error );
+
+        assert.equal(response.data.type, 'MissingMethodException');
+    });
+
+    it('Api should gracefully handle a multicall failure (Async)', async () => {
+        let login = mocks.login;
+        let api = new GeotabApi({
+            credentials: {
+                database: login.credentials.database,
+                userName: login.credentials.username,
+                password: login.credentials.password
+            },
+            path: login.path,
+        }, {rememberMe: false});
+
+        let calls = [
+            ["GetCountOff", { typeName: "Device" }],
+            ["GetCountOf", { typeName: "User" }]
+        ];
+        let call = api.multiCall(calls);
+        let response = await call
+                            .then( result => result )
+                            .catch( err => err );
+        assert.isTrue(response.message.includes('MissingMethodException'), 'Promise response undefined');
+    });
 });

--- a/test/node/node-Credentials-Invalid.spec.js
+++ b/test/node/node-Credentials-Invalid.spec.js
@@ -52,7 +52,7 @@ describe('User loads GeotabApi node module and triggers an error (Credentials)',
         .then( resolved => resolved )
         .catch( error => error );
 
-        assert.startsWith(response.message, 'MissingMethodException');
+        assert.equal(response.data.type, 'MissingMethodException');
     });
 
     it('Api should gracefully handle a call failure (Async)', async () => {


### PR DESCRIPTION
Jira case is [here](https://jira.geotab.com/browse/MYG-57355)

Updated error handling logic to return the error JSON itself when using a callback, rather than an instance of `Error`.