### PR TITLE
Modified puppeteer args to fix failing tests

### DIFF
--- a/test/web/serverSetup.js
+++ b/test/web/serverSetup.js
@@ -18,7 +18,12 @@ const opts = {
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Examples_of_access_control_scenarios
         // Configuring the request to respond to the preflight OPTIONS should also have worked, but this
         // workaround is far easier and faster
-        '--disable-web-security'
+        '--disable-web-security',
+        // Using sandbox triggers this error when calling browser.newPage(): 
+        // [0809/104946.906735:FATAL:gpu_data_manager_impl_private.cc(1034)] The display compositor is frequently crashing. Goodbye.
+        // This causes the call to hang and block the tests from running.
+        // Disabling sandbox in a testing context shouldn't cause any security concerns
+        '--no-sandbox'
     ]
 };
 


### PR DESCRIPTION
The web tests were failing with this error: 

```  
1) User loads web api with credentials
       "before all" hook for "Api Should initialize":
     Error: Timeout of 11000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/wonjuncho/Dev/code/mg-api-js/test/web/web-Credentials.spec.js)
      at listOnTimeout (node:internal/timers:559:17)
      at processTimers (node:internal/timers:502:7)

  2) User loads web api with credentials
       "after all" hook for "Should return axios response objects":
     TypeError: Cannot read properties of undefined (reading 'close')
      at Context.<anonymous> (test/web/web-Credentials.spec.js:258:17)
      at processImmediate (node:internal/timers:466:21)
```

The cause was a puppeteer `browswer.newPage()` call hanging and leaving the following dump after timeout:
```
[0809/104946.238997:WARNING:gpu_process_host.cc(1165)] The GPU process has crashed 1 time(s)
[0809/104946.391314:WARNING:gpu_process_host.cc(1165)] The GPU process has crashed 2 time(s)
[0809/104946.519493:WARNING:gpu_process_host.cc(1165)] The GPU process has crashed 3 time(s)
[0809/104946.653141:WARNING:gpu_process_host.cc(1165)] The GPU process has crashed 4 time(s)
[0809/104946.782035:WARNING:gpu_process_host.cc(1165)] The GPU process has crashed 5 time(s)
[0809/104946.906708:WARNING:gpu_process_host.cc(1165)] The GPU process has crashed 6 time(s)
[0809/104946.906735:FATAL:gpu_data_manager_impl_private.cc(1034)] The display compositor is frequently crashing. Goodbye.
```

The solution was to add `--no-sandbox` arg when launching chromium. Although the flag is generally seen as unsafe, it doesn't pose security threats in a testing context.