### PR TITLE
Update CI to test on Node 18, 20, 22

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,17 +16,16 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
-    - run: npm install
     - run: npm run build
-    - run: npm run test
+    - run: npm run test:node
       env:
         CI: true


### PR DESCRIPTION
## Summary
- Update actions/checkout v2 → v4 and actions/setup-node v1 → v4
- Test matrix: Node 18.x, 20.x, 22.x (drop EOL Node 16)
- Run `test:node` instead of full `test` to avoid Puppeteer setup in CI
- Remove redundant `npm install` after `npm ci`

## Test plan
- [ ] CI pipeline runs successfully on all 3 Node versions in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)