### PR TITLE
Add npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,5 +59,3 @@ jobs:
 
     - name: Publish to npm with provenance
       run: npm publish --provenance --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,14 @@
 # Publishes the package to npm when a GitHub Release is created.
+# Uses npm Trusted Publishing (OIDC) — no static token needed.
 #
-# Setup:
-# 1. Generate an npm access token at https://www.npmjs.com/settings/<user>/tokens
-#    - Choose "Automation" token type (bypasses 2FA for CI)
-# 2. Add it as a repository secret in GitHub:
-#    Settings → Secrets and variables → Actions → New repository secret
-#    Name: NPM_TOKEN
-#    Value: <your token>
+# Setup (one-time on npmjs.com):
+# 1. Go to https://www.npmjs.com/package/mg-api-js/access
+# 2. Under "Publishing access" → Configure Trusted Publishing
+# 3. Add a new trusted publisher:
+#    - Repository owner: Geotab
+#    - Repository name: mg-api-js
+#    - Workflow filename: publish.yml
+#    - Environment: (leave blank)
 #
 # Usage:
 # 1. Bump the version:  npm version patch|minor|major
@@ -23,6 +25,10 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
     - uses: actions/checkout@v4
@@ -51,7 +57,7 @@ jobs:
           exit 1
         fi
 
-    - name: Publish to npm
-      run: npm publish
+    - name: Publish to npm with provenance
+      run: npm publish --provenance --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,57 @@
+# Publishes the package to npm when a GitHub Release is created.
+#
+# Setup:
+# 1. Generate an npm access token at https://www.npmjs.com/settings/<user>/tokens
+#    - Choose "Automation" token type (bypasses 2FA for CI)
+# 2. Add it as a repository secret in GitHub:
+#    Settings → Secrets and variables → Actions → New repository secret
+#    Name: NPM_TOKEN
+#    Value: <your token>
+#
+# Usage:
+# 1. Bump the version:  npm version patch|minor|major
+# 2. Push with tags:    git push && git push --tags
+# 3. Create a GitHub Release from the new tag and add release notes
+# 4. The workflow runs automatically: build → test → publish
+
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20.x
+        registry-url: https://registry.npmjs.org
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Build
+      run: npm run build
+
+    - name: Run tests
+      run: npm run test:node
+
+    - name: Verify version matches tag
+      run: |
+        PACKAGE_VERSION="v$(node -p "require('./package.json').version")"
+        TAG_NAME="${{ github.event.release.tag_name }}"
+        if [ "$PACKAGE_VERSION" != "$TAG_NAME" ]; then
+          echo "Error: package.json version ($PACKAGE_VERSION) does not match release tag ($TAG_NAME)"
+          exit 1
+        fi
+
+    - name: Publish to npm
+      run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that publishes to npm when a GitHub Release is created
- Builds, tests, and verifies the version tag matches `package.json` before publishing
- Requires an `NPM_TOKEN` repository secret (setup instructions in the workflow file)

## Test plan
- [ ] Workflow file is valid YAML and uses correct action versions
- [ ] Test with a pre-release after merging to verify the flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)